### PR TITLE
Drop requirement for tifffile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+* The tifffile package is no longer required
+
 ### Fixed
 
 * Loading of Windows C library for custom installations

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ In other environments, the code can be installed by running:
 python setup.py install
 ```
 
-The code requires the following Python modules: numpy, scipy, tifffile, scikit-image, psutil, h5py, tqdm, numba >=0.41 .
+The code requires the following Python modules: numpy, scipy, scikit-image, psutil, h5py, tqdm, numba >=0.41 .
 For compiling the code, the scikit-build module is required.
 
 To run on GPU (recommended), a CUDA-capable GPU must be present and CUDA drivers must be installed. In addition, please make

--- a/examples/apply_regr.py
+++ b/examples/apply_regr.py
@@ -22,7 +22,7 @@ a network.
 # Import code
 import msdnet
 from pathlib import Path
-import tifffile
+import imageio
 
 # Make folder for output
 outfolder = Path('results')
@@ -39,4 +39,4 @@ for i in range(len(flsin)):
     # Compute network output
     output = n.forward(d.input)
     # Save network output to file
-    tifffile.imsave(outfolder / 'regr_{:05d}.tiff'.format(i), output[0])
+    imageio.imsave(outfolder / 'regr_{:05d}.tiff'.format(i), output[0])

--- a/examples/apply_regr_tomography.py
+++ b/examples/apply_regr_tomography.py
@@ -22,7 +22,7 @@ a network.
 # Import code
 import msdnet
 from pathlib import Path
-import tifffile
+import imageio
 
 # Make folder for output
 outfolder = Path('tomo_results')
@@ -40,4 +40,4 @@ for i in range(len(flsin)):
     # Compute network output
     output = n.forward(dats[i].input)
     # Save network output to file
-    tifffile.imsave(outfolder / 'regr_{:05d}.tiff'.format(i), output[0])
+    imageio.imsave(outfolder / 'regr_{:05d}.tiff'.format(i), output[0])

--- a/examples/apply_segm.py
+++ b/examples/apply_segm.py
@@ -22,7 +22,7 @@ a network.
 # Import code
 import msdnet
 from pathlib import Path
-import tifffile
+import imageio
 import numpy as np
 
 # Make folder for output
@@ -40,6 +40,6 @@ for i in range(len(flsin)):
     # Compute network output
     output = n.forward(d.input)
     # Save labels with maximum probability to file (i.e. prediceted labels for each pixel)
-    tifffile.imsave(outfolder / 'segm_label_{:05d}.tiff'.format(i), np.argmax(output,0).astype(np.uint8))
+    imageio.imsave(outfolder / 'segm_label_{:05d}.tiff'.format(i), np.argmax(output,0).astype(np.uint8))
     # Save probability map of a single channel (here, channel 2) to file
-    tifffile.imsave(outfolder / 'segm_prob_lab2_{:05d}.tiff'.format(i), output[2])
+    imageio.imsave(outfolder / 'segm_prob_lab2_{:05d}.tiff'.format(i), output[2])

--- a/examples/apply_segm_tomography.py
+++ b/examples/apply_segm_tomography.py
@@ -22,7 +22,7 @@ a network.
 # Import code
 import msdnet
 from pathlib import Path
-import tifffile
+import imageio
 import numpy as np
 
 # Make folder for output
@@ -41,6 +41,6 @@ for i in range(len(flsin)):
     # Compute network output
     output = n.forward(dats[i].input)
     # Save labels with maximum probability to file (i.e. prediceted labels for each pixel)
-    tifffile.imsave(outfolder / 'segm_label_{:05d}.tiff'.format(i), np.argmax(output,0).astype(np.uint8))
+    imageio.imsave(outfolder / 'segm_label_{:05d}.tiff'.format(i), np.argmax(output,0).astype(np.uint8))
     # Save probability map of a single channel (here, channel 2) to file
-    tifffile.imsave(outfolder / 'segm_prob_lab2_{:05d}.tiff'.format(i), output[2])
+    imageio.imsave(outfolder / 'segm_prob_lab2_{:05d}.tiff'.format(i), output[2])

--- a/examples/generatedata.py
+++ b/examples/generatedata.py
@@ -19,7 +19,7 @@ This script generates 100 training images, 25 validation images, and
 """
 
 import numpy as np
-import tifffile
+import imageio
 from pathlib import Path
 
 n = 256
@@ -68,9 +68,9 @@ pth.mkdir(exist_ok=True)
 (pth / 'label').mkdir(exist_ok=True)
 for i in range(100):
     imn, im, l = generate()
-    tifffile.imsave(pth / 'noisy' / '{:05d}.tiff'.format(i), imn.astype(np.float32))
-    tifffile.imsave(pth / 'noiseless' / '{:05d}.tiff'.format(i), im.astype(np.float32))
-    tifffile.imsave(pth / 'label' / '{:05d}.tiff'.format(i), l.astype(np.uint8))
+    imageio.imsave(pth / 'noisy' / '{:05d}.tiff'.format(i), imn.astype(np.float32))
+    imageio.imsave(pth / 'noiseless' / '{:05d}.tiff'.format(i), im.astype(np.float32))
+    imageio.imsave(pth / 'label' / '{:05d}.tiff'.format(i), l.astype(np.uint8))
     
 pth = Path('val')
 pth.mkdir(exist_ok=True)
@@ -79,9 +79,9 @@ pth.mkdir(exist_ok=True)
 (pth / 'label').mkdir(exist_ok=True)
 for i in range(25):
     imn, im, l = generate()
-    tifffile.imsave(pth / 'noisy' / '{:05d}.tiff'.format(i), imn.astype(np.float32))
-    tifffile.imsave(pth / 'noiseless' / '{:05d}.tiff'.format(i), im.astype(np.float32))
-    tifffile.imsave(pth / 'label' / '{:05d}.tiff'.format(i), l.astype(np.uint8))
+    imageio.imsave(pth / 'noisy' / '{:05d}.tiff'.format(i), imn.astype(np.float32))
+    imageio.imsave(pth / 'noiseless' / '{:05d}.tiff'.format(i), im.astype(np.float32))
+    imageio.imsave(pth / 'label' / '{:05d}.tiff'.format(i), l.astype(np.uint8))
     
 pth = Path('test')
 pth.mkdir(exist_ok=True)
@@ -90,6 +90,6 @@ pth.mkdir(exist_ok=True)
 (pth / 'label').mkdir(exist_ok=True)
 for i in range(10):
     imn, im, l = generate()
-    tifffile.imsave(pth / 'noisy' / '{:05d}.tiff'.format(i), imn.astype(np.float32))
-    tifffile.imsave(pth / 'noiseless' / '{:05d}.tiff'.format(i), im.astype(np.float32))
-    tifffile.imsave(pth / 'label' / '{:05d}.tiff'.format(i), l.astype(np.uint8))    
+    imageio.imsave(pth / 'noisy' / '{:05d}.tiff'.format(i), imn.astype(np.float32))
+    imageio.imsave(pth / 'noiseless' / '{:05d}.tiff'.format(i), im.astype(np.float32))
+    imageio.imsave(pth / 'label' / '{:05d}.tiff'.format(i), l.astype(np.uint8))    

--- a/examples/generatedata_tomography.py
+++ b/examples/generatedata_tomography.py
@@ -20,7 +20,7 @@ This script generates tomographic reconstructions of phantom samples:
 """
 
 import numpy as np
-import tifffile
+import imageio
 from pathlib import Path
 import astra
 
@@ -66,7 +66,7 @@ for tpe in ['tomo_train', 'tomo_val', 'tomo_test']:
         sinogram_lq = sinogram + np.random.normal(size=sinogram.shape, scale=n/10)
         rec_hq = w.reconstruct('FBP', sinogram_hq)
         rec_lq = w.reconstruct('FBP', sinogram_lq)
-        tifffile.imsave(tpe_path / 'lowqual' / '{:05d}.tiff'.format(j), rec_lq)
-        tifffile.imsave(tpe_path / 'highqual' / '{:05d}.tiff'.format(j), rec_hq)
-        tifffile.imsave(tpe_path / 'label' / '{:05d}.tiff'.format(j), ph_label[j])
+        imageio.imsave(tpe_path / 'lowqual' / '{:05d}.tiff'.format(j), rec_lq)
+        imageio.imsave(tpe_path / 'highqual' / '{:05d}.tiff'.format(j), rec_hq)
+        imageio.imsave(tpe_path / 'label' / '{:05d}.tiff'.format(j), ph_label[j])
         

--- a/msdnet/data.py
+++ b/msdnet/data.py
@@ -18,7 +18,6 @@ Below, :math:`N_{c}` is the number of image channels, and :math:`N_{x} \\times N
 
 import numpy as np
 import abc
-import tifffile
 import imageio
 import random
 import collections
@@ -156,9 +155,11 @@ class ImageFileDataPoint(DataPoint):
     
     def __readimage(self, fn):
         try:
-            im = tifffile.imread(fn)
-        except ValueError:
             im = imageio.imread(fn)
+        except Exception:
+            # require tifffile only if imageio fails
+            from skimage.external.tifffile import tifffile
+            im = tifffile.imread(fn)
         return self.__fix_image_dimensions(im)
 
     def getinputarray(self):
@@ -171,9 +172,11 @@ class ImageFileDataPoint(DataPoint):
         if self.mfn is None:
             return None
         try:
-            im = tifffile.imread(self.mfn)
-        except ValueError:
             im = imageio.imread(self.mfn, flatten=True)
+        except Exception:
+            # require tifffile only if imageio fails
+            from skimage.external.tifffile import tifffile
+            im = tifffile.imread(self.mfn)
         return im
 
 class OneHotDataPoint(DataPoint):


### PR DESCRIPTION
Changes proposed in this pull request:

* Drop requirement for tifffile since it is very difficult to build.  pypi only provides wheels for intel architecture. There are tiff readers in imageio and skimage, so there is no loss in functionality.

Checklist:

* [X] Update CHANGELOG.md
