### PR TITLE
NumPy 2.0 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
+* Replaced `np.Inf` with `np.inf` and `np.int` with `np.int32` for compatibility with **NumPy 2.0**
+
 ### Removed
 
 ## [2.0.0] - 2020-09-14

--- a/examples/generatedata.py
+++ b/examples/generatedata.py
@@ -47,7 +47,7 @@ def generate():
     while i<nit:
         found=False
         while found==False:
-            x, y = (np.random.random(2)*(n-sz)).astype(np.int)
+            x, y = (np.random.random(2)*(n-sz)).astype(np.int32)
             if l[x:x+sz,y:y+sz].max()==0:
                 found=True
         vl = np.random.random()*0.8+0.2

--- a/msdnet/data.py
+++ b/msdnet/data.py
@@ -91,7 +91,7 @@ class BatchProvider(object):
         self.d = dlist
         self.nd = len(self.d)
         self.rndm = np.random.RandomState(seed)
-        self.idx = np.arange(self.nd,dtype=np.int)
+        self.idx = np.arange(self.nd,dtype=np.int32)
         self.rndm.shuffle(self.idx)
         self.bsize = batchsize
         self.i = 0

--- a/msdnet/validate.py
+++ b/msdnet/validate.py
@@ -81,7 +81,7 @@ class LossValidation(Validation):
     def __init__(self, data, loss=None, keep=True):
         self.d = data
         self.keep = keep
-        self.best = np.Inf
+        self.best = np.inf
         self.loss = loss
     
     def errorfunc(self, output, target, msk):
@@ -151,8 +151,8 @@ class LossValidation(Validation):
         errs = np.zeros(len(self.d))
         if self.keep:
             self.outputs = [0,0,0]
-        low = np.Inf
-        high = -np.Inf
+        low = np.inf
+        high = -np.inf
         self.idx = [0,0,0]
         for i,d in enumerate(self.d):
             out = self.n.forward(d.input)


### PR DESCRIPTION
Changes proposed in this pull request:

* Replaced `np.Inf` with `np.inf` and `np.int` with `np.int32` for compatibility with **NumPy 2.0** (and NumPy >= 1.2)

Checklist:

* [x] Update CHANGELOG.md
